### PR TITLE
Add support for multiple file URLs, using an action sheet

### DIFF
--- a/TTOpenInAppActivity/TTOpenInAppActivity.m
+++ b/TTOpenInAppActivity/TTOpenInAppActivity.m
@@ -11,17 +11,19 @@
 #import "TTOpenInAppActivity.h"
 #import <MobileCoreServices/MobileCoreServices.h> // For UTI
 
-@interface TTOpenInAppActivity ()
-    // Private attributes
-    @property (nonatomic, strong) NSURL *fileURL;
-    @property (atomic) CGRect rect;
-    @property (nonatomic, strong) UIBarButtonItem *barButtonItem;
-    @property (nonatomic, strong) UIView *superView;
-    @property (nonatomic, strong) UIDocumentInteractionController *docController;
+@interface TTOpenInAppActivity () <UIActionSheetDelegate>
 
-    // Private methods
-    - (NSString *)UTIForURL:(NSURL *)url;
-    - (void)openDocumentInteractionController;
+// Private attributes
+@property (nonatomic, strong) NSArray *fileURLs;
+@property (atomic) CGRect rect;
+@property (nonatomic, strong) UIBarButtonItem *barButtonItem;
+@property (nonatomic, strong) UIView *superView;
+@property (nonatomic, strong) UIDocumentInteractionController *docController;
+
+// Private methods
+- (NSString *)UTIForURL:(NSURL *)url;
+- (void)openDocumentInteractionControllerWithFileURL:(NSURL *)fileURL;
+- (void)openSelectFileActionSheet;
 
 @end
 
@@ -76,16 +78,20 @@
 		}
 	}
 	
-	return (count == 1);
+	return (count >= 1);
 }
 
 - (void)prepareWithActivityItems:(NSArray *)activityItems
 {
+    NSMutableArray *fileURLs = [NSMutableArray array];
+    
 	for (id activityItem in activityItems) {
 		if ([activityItem isKindOfClass:[NSURL class]] && [(NSURL *)activityItem isFileURL]) {
-			self.fileURL = activityItem;
+            [fileURLs addObject:activityItem];
 		}
 	}
+    
+    self.fileURLs = [fileURLs copy];
 }
 
 - (void)performActivity
@@ -99,14 +105,24 @@
     if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone){
         // iPhone dismiss UIActivityViewController
         [self.superViewController dismissViewControllerAnimated:YES completion:^(void){
-            // Open UIDocumentInteractionController
-            [self openDocumentInteractionController];
+            if (self.fileURLs.count > 1) {
+                [self openSelectFileActionSheet];
+            }
+            else {
+                // Open UIDocumentInteractionController
+                [self openDocumentInteractionControllerWithFileURL:self.fileURLs.lastObject];
+            }
         }];
     } else {
         [self.superViewController dismissPopoverAnimated:YES];
         [((UIPopoverController *)self.superViewController).delegate popoverControllerDidDismissPopover:self.superViewController];
-        // Open UIDocumentInteractionController
-        [self openDocumentInteractionController];
+        if (self.fileURLs.count > 1) {
+            [self openSelectFileActionSheet];
+        }
+        else {
+            // Open UIDocumentInteractionController
+            [self openDocumentInteractionControllerWithFileURL:self.fileURLs.lastObject];
+        }
     }
 }
 
@@ -117,12 +133,12 @@
     return (NSString *)CFBridgingRelease(UTI) ;
 }
 
-- (void)openDocumentInteractionController
+- (void)openDocumentInteractionControllerWithFileURL:(NSURL *)fileURL
 {
     // Open "Open in"-menu
-    self.docController = [UIDocumentInteractionController interactionControllerWithURL:self.fileURL];
+    self.docController = [UIDocumentInteractionController interactionControllerWithURL:fileURL];
     self.docController.delegate = self;
-    self.docController.UTI = [self UTIForURL:self.fileURL];
+    self.docController.UTI = [self UTIForURL:fileURL];
     BOOL sucess; // Sucess is true if it was possible to open the controller and there are apps available
     
     if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone){
@@ -155,12 +171,45 @@
     }
 }
 
+- (void)openSelectFileActionSheet
+{
+    UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:NSLocalizedString(@"Select a file", nil)
+                                                             delegate:self
+                                                    cancelButtonTitle:nil
+                                               destructiveButtonTitle:nil
+                                                    otherButtonTitles:nil];
+    
+    for (NSURL *fileURL in self.fileURLs) {
+        [actionSheet addButtonWithTitle:[fileURL lastPathComponent]];
+    }
+    
+    actionSheet.cancelButtonIndex = [actionSheet addButtonWithTitle:NSLocalizedString(@"Cancel", nil)];
+    
+    if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone){
+        [actionSheet showFromRect:CGRectZero inView:self.superView animated:YES];
+    } else {
+        if(self.barButtonItem)
+            [actionSheet showFromBarButtonItem:self.barButtonItem animated:YES];
+        else
+            [actionSheet showFromRect:self.rect inView:self.superView animated:YES];
+    }
+}
+
 #pragma mark - UIDocumentInteractionControllerDelegate
 
 - (void) documentInteractionControllerDidDismissOpenInMenu: (UIDocumentInteractionController *) controller
 {
     // Inform app that the activity has finished
     [self activityDidFinish:YES];
+}
+
+#pragma mark - Action sheet delegate
+
+- (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
+{
+    if (buttonIndex != actionSheet.cancelButtonIndex) {
+        [self openDocumentInteractionControllerWithFileURL:self.fileURLs[buttonIndex]];
+    }
 }
 
 @end


### PR DESCRIPTION
If multiple local files URLs are detected, we present an `UIActionSheet` to let the user decide which file he wants to open.
