### PR TITLE
Signal action as finished when data was send, not when popup was closed.

### DIFF
--- a/TTOpenInAppActivity/TTOpenInAppActivity.m
+++ b/TTOpenInAppActivity/TTOpenInAppActivity.m
@@ -234,7 +234,7 @@
 
 - (void) documentInteractionControllerWillPresentOpenInMenu:(UIDocumentInteractionController *)controller
 {
-    // iÍnform delegate
+    // Inform delegate
     if([self.delegate respondsToSelector:@selector(openInAppActivityWillPresentDocumentInteractionController:)]) {
         [self.delegate openInAppActivityWillPresentDocumentInteractionController:self];
     }
@@ -246,7 +246,10 @@
     if([self.delegate respondsToSelector:@selector(openInAppActivityDidDismissDocumentInteractionController:)]) {
         [self.delegate openInAppActivityDidDismissDocumentInteractionController:self];
     }
-    
+}
+
+- (void) documentInteractionController:(UIDocumentInteractionController *)controller didEndSendingToApplication:(NSString *)application
+{
     // Inform app that the activity has finished
     [self activityDidFinish:YES];
 }


### PR DESCRIPTION
In my app I save an image temporary for sharing/opening in other apps and delete it after the action.

It works with your current version of TTOpenInAppActivity in iOS 7. However, in iOS 8 the timings seem to have changed. Now the image gets transferred to the other app _after_ the popup was already dismissed. But since I deleted the image as soon as the action was signaled finished with `activityDidFinish:` there was nothing to send to the other app.

I fixed this by using the `documentInteractionController:didEndSendingToApplication:` delegate method instead, which seems to be the better choice anyways.
