### PR TITLE
make sure to report back which app has opened a file

### DIFF
--- a/TTOpenInAppActivity/TTOpenInAppActivity.h
+++ b/TTOpenInAppActivity/TTOpenInAppActivity.h
@@ -17,6 +17,7 @@
 - (void)openInAppActivityWillPresentDocumentInteractionController:(TTOpenInAppActivity*)activity;
 - (void)openInAppActivityDidDismissDocumentInteractionController:(TTOpenInAppActivity*)activity;
 - (void)openInAppActivityDidEndSendingToApplication:(TTOpenInAppActivity*)activity;
+- (void)openInAppActivityDidSendToApplication:(NSString*)application;
 @end
 
 @interface TTOpenInAppActivity : UIActivity <UIDocumentInteractionControllerDelegate>

--- a/TTOpenInAppActivity/TTOpenInAppActivity.m
+++ b/TTOpenInAppActivity/TTOpenInAppActivity.m
@@ -254,6 +254,9 @@
     if([self.delegate respondsToSelector:@selector(openInAppActivityDidEndSendingToApplication:)]) {
         [self.delegate openInAppActivityDidDismissDocumentInteractionController:self];
     }
+    if ([self.delegate respondsToSelector:@selector(openInAppActivityDidSendToApplication:)]) {
+        [self.delegate openInAppActivityDidSendToApplication:application];
+    }
     
     // Inform app that the activity has finished
     [self activityDidFinish:YES];


### PR DESCRIPTION
This pull request adds a new delegate method that will be passed the application bundleID of the application that ended up opening a file. Note, sometimes this argument is nil.
