### PR TITLE
Add ability to use activity directly without showing in a share sheet

### DIFF
--- a/TTOpenInAppActivity/TTOpenInAppActivity.h
+++ b/TTOpenInAppActivity/TTOpenInAppActivity.h
@@ -30,4 +30,8 @@
 
 - (void)dismissDocumentInteractionControllerAnimated:(BOOL)animated;
 
+// Directly show the document interaction controller without using this activity.
+- (instancetype)initWithActivityItem:(id)item inViewController:(UIViewController *)viewController andRect:(CGRect)rect;
+- (void)showDocumentInteractionController;
+
 @end

--- a/TTOpenInAppActivity/TTOpenInAppActivity.m
+++ b/TTOpenInAppActivity/TTOpenInAppActivity.m
@@ -20,6 +20,7 @@
 @property (nonatomic, strong) UIBarButtonItem *barButtonItem;
 @property (nonatomic, strong) UIView *superView;
 @property (nonatomic, strong) UIDocumentInteractionController *docController;
+@property (nonatomic, strong) NSArray *activityItems;
 
 // Private methods
 - (NSString *)UTIForURL:(NSURL *)url;
@@ -65,6 +66,32 @@
     }
     return self;
 }
+
+#pragma mark - direct documentInteractionController access
+
+- (instancetype)initWithActivityItem:(id)item inViewController:(UIViewController *)viewController andRect:(CGRect)rect
+{
+    if (self = [super init]) {
+        self.superViewController = viewController;
+        self.superView = self.superView ?: viewController.view;
+        self.rect = rect;
+        self.activityItems = @[item];
+    }
+    return self;
+}
+
+- (void)showDocumentInteractionController
+{
+    NSAssert(self.activityItems,@"You must set activityItems when directly showing the documentInteractionController.");
+    NSAssert(self.superViewController,@"You must set a superViewController when directly showing the documentInteractionController.");
+    NSAssert(self.superView,@"You must set a superView when directly showing the documentInteractionController.");
+    if ([self canPerformWithActivityItems:self.activityItems]) {
+        [self prepareWithActivityItems:self.activityItems];
+        [self performActivity];
+    }
+}
+
+#pragma mark -
 
 - (NSString *)activityType
 {


### PR DESCRIPTION
I had a use case where I was showing the open in icon inside my own chrome, and wanted to just directly trigger the `documentInteractionHandler`, without re-writing the iPad/iPhone detection and the other niceties of this library.

This pull adds 2 methods:

``` objective-c
- (instancetype)initWithActivityItem:(id)item inViewController:(UIViewController *)viewController andRect:(CGRect)rect;
```

This method just is an initializer with a single item and vc, which allows us to use this activityItem outside of a standard `activityItem` context (it stores the activityItems internally, automatically calling `canPerform` and `prepareWith` methods).

and

``` objective-c
- (void)showDocumentInteractionController;
```

Which will just present the interaction controller with the `superViewController`, `superView` and `CGRect` currently set on the activity.
