### PR TITLE
avert crash

### DIFF
--- a/TTOpenInAppActivity/TTOpenInAppActivity.m
+++ b/TTOpenInAppActivity/TTOpenInAppActivity.m
@@ -315,5 +315,10 @@
     return fileURL;
 }
 
+- (void)dealloc
+{
+    self.docController.delegate = nil;
+}
+
 @end
 


### PR DESCRIPTION
I've seen a bunch of crashes in my app where the UIDocumentInteractionController tries to call delegate methods when the TTOpenInActivity object is long gone. This makes sure to clear the docController's delegate when we go away, to avoid that.